### PR TITLE
Add `@property` overrides to prevent false IDE errors

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -7,6 +7,9 @@ use Illuminate\Support\Str;
 
 /**
  * Wrapper for Laravel/Illuminate Collection class.
+ *
+ * @property \Rgasch\Collection\Collection $min
+ * @property \Rgasch\Collection\Collection $max
  */
 class Collection extends \Illuminate\Support\Collection
 {


### PR DESCRIPTION
Since from the tests I gather that there should be no problem using ->min and ->max for these collections, so this PR adds new `@property` tags to override the default `@property-read` ones. But it's a 30-second PR to make, I won't get hurt if you don't want to merge this on account of adding bloat to the class. Up to you.

Before:

![image](https://user-images.githubusercontent.com/95144705/202912738-d463e567-b6ac-4c96-b165-adbb723f71ba.png)


After:

![image](https://user-images.githubusercontent.com/95144705/202912747-52fb72dc-fe6d-476e-b2ab-cb7059ad9005.png)
